### PR TITLE
fix: send auth token with API requests

### DIFF
--- a/client/src/components/CardForm.tsx
+++ b/client/src/components/CardForm.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, authHeaders } from "@/lib/queryClient";
 import { queryClient } from "@/lib/queryClient";
 import { KaTeXComponent } from "@/lib/katex";
 import { Tag } from "@shared/schema";
@@ -74,7 +74,7 @@ export default function CardForm({ isOpen, onClose, editCard }: CardFormProps) {
   useEffect(() => {
     const fetchTags = async () => {
       try {
-        const response = await fetch("/api/tags");
+        const response = await fetch("/api/tags", { headers: authHeaders() });
         if (!response.ok) {
           throw new Error("Failed to fetch tags");
         }

--- a/client/src/components/TagFilter.tsx
+++ b/client/src/components/TagFilter.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { Tag } from "@shared/schema";
+import { authHeaders } from "@/lib/queryClient";
 
 type TagFilterProps = {
   onTagsChange: (selectedTagIds: number[]) => void;
@@ -20,7 +21,7 @@ export default function TagFilter({ onTagsChange }: TagFilterProps) {
   useEffect(() => {
     const fetchTags = async () => {
       try {
-        const response = await fetch("/api/tags");
+        const response = await fetch("/api/tags", { headers: authHeaders() });
         if (!response.ok) {
           throw new Error("Failed to fetch tags");
         }

--- a/client/src/components/TagManager.tsx
+++ b/client/src/components/TagManager.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import TagForm from "./TagForm";
 import { Card } from "@/components/ui/card";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, authHeaders } from "@/lib/queryClient";
 import { queryClient } from "@/lib/queryClient";
 
 export default function TagManager() {
@@ -23,7 +23,7 @@ export default function TagManager() {
     const fetchTags = async () => {
       try {
         setIsLoading(true);
-        const response = await fetch("/api/tags");
+        const response = await fetch("/api/tags", { headers: authHeaders() });
         if (!response.ok) {
           throw new Error("Failed to fetch tags");
         }
@@ -166,7 +166,7 @@ export default function TagManager() {
           queryClient.invalidateQueries({ queryKey: ["/api/tags"] });
           const fetchTags = async () => {
             try {
-              const response = await fetch("/api/tags");
+              const response = await fetch("/api/tags", { headers: authHeaders() });
               if (!response.ok) {
                 throw new Error("Failed to fetch tags");
               }

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -7,6 +7,11 @@ async function throwIfResNotOk(res: Response) {
   }
 }
 
+export function authHeaders(): HeadersInit {
+  const token = localStorage.getItem("authToken");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 export async function apiRequest(
   method: string,
   url: string,
@@ -14,7 +19,10 @@ export async function apiRequest(
 ): Promise<Response> {
   const res = await fetch(url, {
     method,
-    headers: data ? { "Content-Type": "application/json" } : {},
+    headers: {
+      ...(data ? { "Content-Type": "application/json" } : {}),
+      ...authHeaders(),
+    },
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
   });
@@ -31,6 +39,7 @@ export const getQueryFn: <T>(options: {
   async ({ queryKey }) => {
     const res = await fetch(queryKey[0] as string, {
       credentials: "include",
+      headers: authHeaders(),
     });
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { FlashcardWithTags } from "@shared/schema";
 import { useMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
+import { authHeaders } from "@/lib/queryClient";
 
 export default function Home() {
   const [isCardFormOpen, setIsCardFormOpen] = useState(false);
@@ -38,7 +39,7 @@ export default function Home() {
         ? selectedTagIds.map(id => `tags=${id}`).join('&') 
         : '';
       const queryParams = `q=${encodeURIComponent(searchQuery)}${tagParams ? `&${tagParams}` : ''}`;
-      const response = await fetch(`/api/flashcards/search?${queryParams}`);
+      const response = await fetch(`/api/flashcards/search?${queryParams}`, { headers: authHeaders() });
       if (!response.ok) {
         throw new Error('Failed to search flashcards');
       }


### PR DESCRIPTION
## Summary
- include Replit auth token in every client API call
- ensure tag and flashcard fetches send Authorization headers

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68964ea5f478832abfee8888c3a1cb7d