### PR TITLE
Add user ID to authentication headers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,17 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { Suspense, useEffect, useState } from "react";
 
+function decodeUserId(token: string): string | null {
+  try {
+    const payload = JSON.parse(
+      atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/"))
+    );
+    return payload.sub || payload.user_id || payload.userId || null;
+  } catch {
+    return null;
+  }
+}
+
 function Router() {
   return (
     <Switch>
@@ -25,6 +36,10 @@ function App() {
   useEffect(() => {
     const existing = localStorage.getItem("authToken");
     if (existing) {
+      const id = decodeUserId(existing);
+      if (id) {
+        localStorage.setItem("userId", id);
+      }
       queryClient.setDefaultOptions({
         queries: { retry: false, refetchOnWindowFocus: false },
       });
@@ -38,6 +53,10 @@ function App() {
       const token = await (window as any).auth?.("flashcards-app");
       if (token) {
         localStorage.setItem("authToken", token);
+        const id = decodeUserId(token);
+        if (id) {
+          localStorage.setItem("userId", id);
+        }
         queryClient.setDefaultOptions({
           queries: { retry: false, refetchOnWindowFocus: false },
         });

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -9,7 +9,15 @@ async function throwIfResNotOk(res: Response) {
 
 export function authHeaders(): HeadersInit {
   const token = localStorage.getItem("authToken");
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  const userId = localStorage.getItem("userId");
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  if (userId) {
+    headers["X-Replit-User-Id"] = userId;
+  }
+  return headers;
 }
 
 export async function apiRequest(


### PR DESCRIPTION
## Summary
- Decode auth token to capture user ID and store it locally
- Send both `Authorization` and `X-Replit-User-Id` headers on API requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68965a0ef414832a94e23db834dc6fd1