### PR TITLE
fix: preserve query client auth headers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,9 +40,6 @@ function App() {
       if (id) {
         localStorage.setItem("userId", id);
       }
-      queryClient.setDefaultOptions({
-        queries: { retry: false, refetchOnWindowFocus: false },
-      });
       setReady(true);
       return;
     }
@@ -57,9 +54,6 @@ function App() {
         if (id) {
           localStorage.setItem("userId", id);
         }
-        queryClient.setDefaultOptions({
-          queries: { retry: false, refetchOnWindowFocus: false },
-        });
         setReady(true);
       }
     };


### PR DESCRIPTION
## Summary
- remove redundant `setDefaultOptions` calls so the custom `queryFn` remains active

## Testing
- `npm test`